### PR TITLE
Random seed

### DIFF
--- a/sources/iceCube/uhe/event/I3Juliet.cxx
+++ b/sources/iceCube/uhe/event/I3Juliet.cxx
@@ -36,6 +36,7 @@ const int doTauPN   = 1;
 const int doMuDecay = 1;
 const int doTauDecay= 1;
 const int startlocationID = 1; //[1=from earth entrance: 2=800m away from IceCube origin]
+const long random_seed = 1337;
 
 using namespace std;
 
@@ -161,12 +162,13 @@ void I3Juliet::GenerateJULIeT(bool isInteractive)
 
      fJULIeTObj = 
         fJNIEnv->NewObject(fJULIeT, fJNIEnv->GetMethodID(fJULIeT, "<init>", 
-                       "(IIDIIIIIIIIIIIIIIIIII)V"), 
+                       "(IIDIIIIIIIIIIIIIIIIIIL)V"), 
                        flavorID, doubletID, energy, matID,
                        doCC, doNC, doMuBrem, doTauBrem, doMuKnock, doTauKnock,
                        doMu2e, doTau2e, doMu2mu, doTau2mu,
                        doMu2tau, doTau2tau, doMuPN, doTauPN,
-                       doMuDecay, doTauDecay, startlocationID);
+                       doMuDecay, doTauDecay, startlocationID,
+                       random_seed);
   }
 
 }

--- a/sources/iceCube/uhe/event/I3Juliet.cxx
+++ b/sources/iceCube/uhe/event/I3Juliet.cxx
@@ -162,7 +162,7 @@ void I3Juliet::GenerateJULIeT(bool isInteractive)
 
      fJULIeTObj = 
         fJNIEnv->NewObject(fJULIeT, fJNIEnv->GetMethodID(fJULIeT, "<init>", 
-                       "(IIDIIIIIIIIIIIIIIIIIIL)V"), 
+                       "(IIDIIIIIIIIIIIIIIIIIIJ)V"), 
                        flavorID, doubletID, energy, matID,
                        doCC, doNC, doMuBrem, doTauBrem, doMuKnock, doTauKnock,
                        doMu2e, doTau2e, doMu2mu, doTau2mu,

--- a/sources/iceCube/uhe/event/JulietEventGenerator.java
+++ b/sources/iceCube/uhe/event/JulietEventGenerator.java
@@ -170,6 +170,52 @@ public class JulietEventGenerator {
                                 int doMuKnock, int doTauKnock, int doMu2e, int doTau2e,
                                 int doMu2mu, int doTau2mu, int doMu2tau, int doTau2tau,
                                 int doMuPN, int doTauPN, int doGR, int doMuDecay,
+                                int doTauDecay, int posID) throws IOException{
+
+        long[] random_state = null;
+        long seed = -1;
+
+        configureJULIeT(flavorID, doubletID, energy, mediumID, 
+                        doCC, doNC, doMuBrems, doTauBrems, 
+                        doMuKnock, doTauKnock, doMu2e, doTau2e,
+                        doMu2mu, doTau2mu, doMu2tau, doTau2tau,
+                        doMuPN, doTauPN, doGR, doMuDecay,
+                        doTauDecay, posID, seed, random_state);
+
+    }
+
+
+    /** The same constructor, but without the glashow resoanance. 
+	This constructor exists to maintain the backward compatibility
+    */
+    public JulietEventGenerator(int flavorID, int doubletID, double energy, int mediumID, 
+                                int doCC, int doNC, int doMuBrems, int doTauBrems, 
+                                int doMuKnock, int doTauKnock, int doMu2e, int doTau2e,
+                                int doMu2mu, int doTau2mu, int doMu2tau, int doTau2tau,
+                                int doMuPN, int doTauPN, int doMuDecay,
+                                int doTauDecay, int posID) throws IOException{
+
+	    int doGR = 0;
+        long[] random_state = null;
+        long seed = -1;
+
+        configureJULIeT(flavorID, doubletID, energy, mediumID, 
+                        doCC, doNC, doMuBrems, doTauBrems, 
+                        doMuKnock, doTauKnock, doMu2e, doTau2e,
+                        doMu2mu, doTau2mu, doMu2tau, doTau2tau,
+                        doMuPN, doTauPN, doGR, doMuDecay,
+                        doTauDecay, posID, seed, random_state);
+
+    }
+
+    /**
+      Constructor using the seed for the random generator.
+    */
+    public JulietEventGenerator(int flavorID, int doubletID, double energy, int mediumID, 
+                                int doCC, int doNC, int doMuBrems, int doTauBrems, 
+                                int doMuKnock, int doTauKnock, int doMu2e, int doTau2e,
+                                int doMu2mu, int doTau2mu, int doMu2tau, int doTau2tau,
+                                int doMuPN, int doTauPN, int doGR, int doMuDecay,
                                 int doTauDecay, int posID, long seed) throws IOException{
 
         long[] random_state = null;
@@ -184,7 +230,7 @@ public class JulietEventGenerator {
     }
 
     /** The same constructor, but without the glashow resoanance. 
-	This constructor exists to maintain the backward compatibility
+    This constructor exists to maintain the backward compatibility
     */
     public JulietEventGenerator(int flavorID, int doubletID, double energy, int mediumID, 
                                 int doCC, int doNC, int doMuBrems, int doTauBrems, 
@@ -193,7 +239,7 @@ public class JulietEventGenerator {
                                 int doMuPN, int doTauPN, int doMuDecay,
                                 int doTauDecay, int posID, long seed) throws IOException{
 
-	    int doGR = 0;
+        int doGR = 0;
         long[] random_state = null;
 
         configureJULIeT(flavorID, doubletID, energy, mediumID, 

--- a/sources/iceCube/uhe/event/JulietEventGenerator.java
+++ b/sources/iceCube/uhe/event/JulietEventGenerator.java
@@ -215,7 +215,7 @@ public class JulietEventGenerator {
                                 int doMuPN, int doTauPN, int doGR, int doMuDecay,
                                 int doTauDecay, int posID, long[] random_state) throws IOException{
 
-        long seed = null;
+        long seed = -1;
 
         configureJULIeT(flavorID, doubletID, energy, mediumID, 
                         doCC, doNC, doMuBrems, doTauBrems, 
@@ -372,16 +372,18 @@ public class JulietEventGenerator {
         materialNumber = mediumID;
 
         // Generate Random Generator
-        if(seed != null){
+        if(seed != -1){
+          System.out.println("Using seed to setup Random Generator");
           rand = new RandomGenerator(seed);
         }
         else if(random_state != null){
-            rand = new RandomGenerator(random_state);
+          System.out.println("Using random_state to setup Random Generator");
+          rand = new RandomGenerator(random_state);
         }
         else{
-            rand = new RandomGenerator();
+          System.out.println("Using system time to setup Random Generator");
+          rand = new RandomGenerator();
         }
-        System.out.println("Random Generator has been generated");
 
         // Register Interactions and read the InteractionMatrix objects
 	    /** For Glashow Resonance 16->20*/
@@ -1143,6 +1145,10 @@ public class JulietEventGenerator {
     public long[] getRandomState(){
         long[] state = rand.GetState();
         return state;
+    }
+
+    public void setRandomState(long[] state){
+        rand = new RandomGenerator(state);
     }
 
     /** Method to run multiple events (numberOfEvent) 

--- a/sources/iceCube/uhe/event/JulietEventGenerator.java
+++ b/sources/iceCube/uhe/event/JulietEventGenerator.java
@@ -147,7 +147,6 @@ public class JulietEventGenerator {
     List locationIce3List = null;
     ListIterator locationIce3Iterator = null;
     List particleInteractionsList = null;
-    ListIterator particleInteractionIterator = null;
 
     /** List of the track particles and 
         the interaction points */
@@ -418,13 +417,13 @@ public class JulietEventGenerator {
         materialNumber = mediumID;
 
         // Generate Random Generator
-        if(seed != -1){
-          System.out.println("Using seed to setup Random Generator");
-          rand = new RandomGenerator(seed);
-        }
-        else if(random_state != null){
+        if(random_state != null){
           System.out.println("Using random_state to setup Random Generator");
           rand = new RandomGenerator(random_state);
+        }
+        else if(seed != -1){
+          System.out.println("Using seed to setup Random Generator");
+          rand = new RandomGenerator(seed);
         }
         else{
           System.out.println("Using system time to setup Random Generator");

--- a/sources/iceCube/uhe/event/JulietEventGenerator.java
+++ b/sources/iceCube/uhe/event/JulietEventGenerator.java
@@ -137,6 +137,7 @@ public class JulietEventGenerator {
 
     /** Random Generator */
     RandomGenerator rand;
+    long seed;
 
     /** List of the cascade particles, energy deposite and 
 	the interaction points along the track */
@@ -165,17 +166,15 @@ public class JulietEventGenerator {
                                 int doCC, int doNC, int doMuBrems, int doTauBrems, 
                                 int doMuKnock, int doTauKnock, int doMu2e, int doTau2e,
                                 int doMu2mu, int doTau2mu, int doMu2tau, int doTau2tau,
-                                int doMuPN, int doTauPN, 
-				int doGR,
-				int doMuDecay, int doTauDecay, int posID) throws IOException{
+                                int doMuPN, int doTauPN, int doGR, int doMuDecay,
+                                int doTauDecay, int posID, long seed) throws IOException{
 
         configureJULIeT(flavorID, doubletID, energy, mediumID, 
                         doCC, doNC, doMuBrems, doTauBrems, 
                         doMuKnock, doTauKnock, doMu2e, doTau2e,
                         doMu2mu, doTau2mu, doMu2tau, doTau2tau,
-                        doMuPN, doTauPN, 
-			doGR,
-			doMuDecay, doTauDecay, posID);
+                        doMuPN, doTauPN, doGR, doMuDecay,
+                        doTauDecay, posID, seed);
 
     }
     /** The same constructor, but without the glashow resoanance. 
@@ -185,18 +184,17 @@ public class JulietEventGenerator {
                                 int doCC, int doNC, int doMuBrems, int doTauBrems, 
                                 int doMuKnock, int doTauKnock, int doMu2e, int doTau2e,
                                 int doMu2mu, int doTau2mu, int doMu2tau, int doTau2tau,
-                                int doMuPN, int doTauPN, 
-				int doMuDecay, int doTauDecay, int posID) throws IOException{
+                                int doMuPN, int doTauPN, int doMuDecay,
+                                int doTauDecay, int posID, long seed) throws IOException{
 
-	int doGR = 0;
+	    int doGR = 0;
 
         configureJULIeT(flavorID, doubletID, energy, mediumID, 
                         doCC, doNC, doMuBrems, doTauBrems, 
                         doMuKnock, doTauKnock, doMu2e, doTau2e,
                         doMu2mu, doTau2mu, doMu2tau, doTau2tau,
-                        doMuPN, doTauPN, 
-			doGR,
-			doMuDecay, doTauDecay, posID);
+                        doMuPN, doTauPN, doGR, doMuDecay,
+                        doTauDecay, posID, seed);
 
     }
     public JulietEventGenerator() throws IOException{
@@ -206,9 +204,10 @@ public class JulietEventGenerator {
         int doMuKnock, doTauKnock, doMu2e, doTau2e;
         int doMu2mu, doTau2mu, doMu2tau, doTau2tau;
         int doMuPN, doTauPN, doMuDecay, doTauDecay, posID;
+        long seed;
 
-	/** For Glashow Resonance */
-	int doGR;
+    	/** For Glashow Resonance */
+    	int doGR;
 
         double energy;
 	
@@ -306,14 +305,17 @@ public class JulietEventGenerator {
 	buffer = d.readLine();
 	posID = Integer.valueOf(buffer).intValue();
 
+    System.out.print("Seed for the RandomGenerator");
+    buffer = d.readLine();
+    seed = Long.valueOf(buffer).longValue();
+
 	/** For Glashow Resonance */
-        configureJULIeT(flavorID, doubletID, energy, mediumID, 
-                        doCC, doNC, doMuBrems, doTauBrems, 
-                        doMuKnock, doTauKnock, doMu2e, doTau2e,
-                        doMu2mu, doTau2mu, doMu2tau, doTau2tau,
-                        doMuPN, doTauPN, 
-			doGR,
-			doMuDecay, doTauDecay, posID);
+    configureJULIeT(flavorID, doubletID, energy, mediumID, 
+                    doCC, doNC, doMuBrems, doTauBrems, 
+                    doMuKnock, doTauKnock, doMu2e, doTau2e,
+                    doMu2mu, doTau2mu, doMu2tau, doTau2tau,
+                    doMuPN, doTauPN, doGR, doMuDecay,
+                    doTauDecay, posID, seed);
     }
 
     /**
@@ -327,9 +329,8 @@ public class JulietEventGenerator {
                                  int doCC, int doNC, int doMuBrems, int doTauBrems, 
                                  int doMuKnock, int doTauKnock, int doMu2e, int doTau2e,
                                  int doMu2mu, int doTau2mu, int doMu2tau, int doTau2tau,
-                                 int doMuPN, int doTauPN, 
-				 int doGR,
-				 int doMuDecay, int doTauDecay, int posID) throws IOException{
+                                 int doMuPN, int doTauPN, int doGR, int doMuDecay,
+                                 int doTauDecay, int posID, long seed) throws IOException{
 
 
         primaryFlavor  = flavorID;
@@ -338,11 +339,11 @@ public class JulietEventGenerator {
         materialNumber = mediumID;
 
         // Generate Random Generator
-        rand = new RandomGenerator();
+        rand = new RandomGenerator(seed);
         System.out.println("Random Generator has been generated");
 
         // Register Interactions and read the InteractionMatrix objects
-	/** For Glashow Resonance 16->20*/
+	    /** For Glashow Resonance 16->20*/
         String[] fileName = new String[20];
         String matrixName = null;
         if(materialNumber==0)  interactionsMatrixDirectory = interactionsMatrixDirectoryInIce;
@@ -917,12 +918,12 @@ public class JulietEventGenerator {
 
 		double transferedEnergy  = event.collideNow(rand);
 
-                // get current interaction's name
-                String   curInteractionsName  = event.interactionsNameInPlay();
+        // get current interaction's name
+        String   curInteractionsName  = event.interactionsNameInPlay();
 
-                // Collision occured by NC, WeakInteraction(CC, NC), Decay or Glashow Resonance?
-                wasWeakInt = curInteractionsName.startsWith("Neutrino-Nuclen ");
-                wasNC      = curInteractionsName.startsWith("Neutrino-Nuclen N");
+        // Collision occured by NC, WeakInteraction(CC, NC), Decay or Glashow Resonance?
+        wasWeakInt = curInteractionsName.startsWith("Neutrino-Nuclen ");
+        wasNC      = curInteractionsName.startsWith("Neutrino-Nuclen N");
 		wasDecay   = (event.mcBaseInPlay.getTypeOfInteraction() == 1);
 		/** For Glashow Resonance */
                 wasGR = curInteractionsName.startsWith("Glashow ");
@@ -936,21 +937,21 @@ public class JulietEventGenerator {
 		//		           event.getFlavorByInteractionsInPlay(),0);
 		//}
 
-                // get current propagation particle
-                Particle curPropParticle        = event.propParticle;
-                int      curPropParticleFlavor  = curPropParticle.getFlavor();
-                int      curPropParticleDoublet = curPropParticle.getDoublet();
-                String   curPropParticleName    = Particle.particleName(curPropParticleFlavor,
-                                                                        curPropParticleDoublet);
+        // get current propagation particle
+        Particle curPropParticle        = event.propParticle;
+        int      curPropParticleFlavor  = curPropParticle.getFlavor();
+        int      curPropParticleDoublet = curPropParticle.getDoublet();
+        String   curPropParticleName    = Particle.particleName(curPropParticleFlavor,
+                                                                curPropParticleDoublet);
 
                 
 		//System.out.println("Colliding via " + curInteractionsName +
 		//            " and producing " + producedParticleName);
 		//System.out.println("  -Current propagation particle : " + curPropParticleName);
 
-                // add prpagation track to the lists
-                boolean addTrack = false;
-                if (curPropParticleFlavor == 1) { // muon flavor
+        // add prpagation track to the lists
+        boolean addTrack = false;
+        if (curPropParticleFlavor == 1) { // muon flavor
 
 		    if (wasWeakInt || wasDecay || wasGR) addTrack = true;
 
@@ -964,12 +965,12 @@ public class JulietEventGenerator {
 		    }
 		}
 
-                if (addTrack) {
-                   trackParticleList.add(new Particle(curPropParticle.getFlavor(), 
-                                                      curPropParticle.getDoublet(),
-                                                      curPropParticle.getEnergy())); 
-                   trackLocationIce3List.add(particleLocation_J3Vector_ice3);
-                }
+        if (addTrack) {
+           trackParticleList.add(new Particle(curPropParticle.getFlavor(), 
+                                              curPropParticle.getDoublet(),
+                                              curPropParticle.getEnergy())); 
+           trackLocationIce3List.add(particleLocation_J3Vector_ice3);
+        }
 
                 // add secondary cascade to the lists
 		if ((event.getFlavorByInteractionsInPlay()==0 && !wasGR) || 
@@ -994,11 +995,11 @@ public class JulietEventGenerator {
 
 	    double afterInteractionLogEnergy = event.propParticle.getLogEnergy(); 
                                            // logEnergy after interaction
-            double afterInteractionEnergy = event.propParticle.getEnergy();
+        double afterInteractionEnergy = event.propParticle.getEnergy();
                                            // Energy after interaction
         
-            //System.out.println("logEnergy after interaction is  "+ afterInteractionLogEnergy);
-            //System.out.println("Energy after interaction is  "+ afterInteractionEnergy);
+        //System.out.println("logEnergy after interaction is  "+ afterInteractionLogEnergy);
+        //System.out.println("Energy after interaction is  "+ afterInteractionEnergy);
 
 	    if ((afterInteractionLogEnergy <= InteractionsBase.getLogEnergyProducedMinimum()) || 
                 (wasNC && afterInteractionEnergy < neutrinoMinimumEnergyInTravel)){
@@ -1094,7 +1095,6 @@ public class JulietEventGenerator {
     }
 
 
-
     /** Method to run multiple events (numberOfEvent) 
         with various primary energies from
 	logE = Particle.getLogEnergyMinimum() all the way up to 10^12 GeV.
@@ -1105,7 +1105,7 @@ public class JulietEventGenerator {
 	
 	for(int iLogE=0; iLogE<dim; iLogE++){
 	    primaryiLogE = iLogE;
-//System.out.println(iLogE);
+        //System.out.println(iLogE);
 	    double logPrimaryEnergy = 
 		Particle.getDeltaLogEnergy()*(double )iLogE + Particle.getLogEnergyMinimum();
 	    primaryEnergy = Math.pow(10.0,logPrimaryEnergy);

--- a/sources/iceCube/uhe/event/JulietEventGenerator4Gen2.java
+++ b/sources/iceCube/uhe/event/JulietEventGenerator4Gen2.java
@@ -154,6 +154,8 @@ public class JulietEventGenerator4Gen2 {
 
     /** Random Generator */
     RandomGenerator rand;
+    long seed;
+    long[] random_state;
 
     /** List of the cascade particles, energy deposite and 
 	the interaction points along the track */
@@ -161,6 +163,7 @@ public class JulietEventGenerator4Gen2 {
     ListIterator particleIterator = null;
     List locationIce3List = null;
     ListIterator locationIce3Iterator = null;
+    List particleInteractionsList = null;
 
     /** List of the track particles and 
         the interaction points */
@@ -179,43 +182,111 @@ public class JulietEventGenerator4Gen2 {
       object is generated in an interactive way to an user.
     */
     public JulietEventGenerator4Gen2(int flavorID, int doubletID, double energy, int mediumID, 
-                                int doCC, int doNC, int doMuBrems, int doTauBrems, 
-                                int doMuKnock, int doTauKnock, int doMu2e, int doTau2e,
-                                int doMu2mu, int doTau2mu, int doMu2tau, int doTau2tau,
-                                int doMuPN, int doTauPN, 
-				int doGR,
-				int doMuDecay, int doTauDecay, int posID) throws IOException{
+                                     int doCC, int doNC, int doMuBrems, int doTauBrems, 
+                                     int doMuKnock, int doTauKnock, int doMu2e, int doTau2e,
+                                     int doMu2mu, int doTau2mu, int doMu2tau, int doTau2tau,
+                                     int doMuPN, int doTauPN, int doGR, int doMuDecay,
+                                     int doTauDecay, int posID) throws IOException{
+        long[] random_state = null;
+        long seed = -1;
 
         configureJULIeT(flavorID, doubletID, energy, mediumID, 
                         doCC, doNC, doMuBrems, doTauBrems, 
                         doMuKnock, doTauKnock, doMu2e, doTau2e,
                         doMu2mu, doTau2mu, doMu2tau, doTau2tau,
-                        doMuPN, doTauPN, 
-			doGR,
-			doMuDecay, doTauDecay, posID);
+                        doMuPN, doTauPN, doGR, doMuDecay,
+                        doTauDecay, posID, seed, random_state);
 
     }
     /** The same constructor, but without the glashow resoanance. 
 	This constructor exists to maintain the backward compatibility
     */
     public JulietEventGenerator4Gen2(int flavorID, int doubletID, double energy, int mediumID, 
-                                int doCC, int doNC, int doMuBrems, int doTauBrems, 
-                                int doMuKnock, int doTauKnock, int doMu2e, int doTau2e,
-                                int doMu2mu, int doTau2mu, int doMu2tau, int doTau2tau,
-                                int doMuPN, int doTauPN, 
-				int doMuDecay, int doTauDecay, int posID) throws IOException{
+                                     int doCC, int doNC, int doMuBrems, int doTauBrems, 
+                                     int doMuKnock, int doTauKnock, int doMu2e, int doTau2e,
+                                     int doMu2mu, int doTau2mu, int doMu2tau, int doTau2tau,
+                                     int doMuPN, int doTauPN, int doMuDecay,
+                                     int doTauDecay, int posID) throws IOException{
 
-	int doGR = 0;
+	    int doGR = 0;
+        long[] random_state = null;
+        long seed = -1;
 
         configureJULIeT(flavorID, doubletID, energy, mediumID, 
                         doCC, doNC, doMuBrems, doTauBrems, 
                         doMuKnock, doTauKnock, doMu2e, doTau2e,
                         doMu2mu, doTau2mu, doMu2tau, doTau2tau,
-                        doMuPN, doTauPN, 
-			doGR,
-			doMuDecay, doTauDecay, posID);
+                        doMuPN, doTauPN, doGR, doMuDecay,
+                        doTauDecay, posID, seed, random_state);
 
     }
+
+    /**
+      Constructor using the seed for the random generator.
+    */
+    public JulietEventGenerator4Gen2(int flavorID, int doubletID, double energy, int mediumID, 
+                                     int doCC, int doNC, int doMuBrems, int doTauBrems, 
+                                     int doMuKnock, int doTauKnock, int doMu2e, int doTau2e,
+                                     int doMu2mu, int doTau2mu, int doMu2tau, int doTau2tau,
+                                     int doMuPN, int doTauPN, int doGR, int doMuDecay,
+                                     int doTauDecay, int posID, long seed) throws IOException{
+
+        long[] random_state = null;
+
+        configureJULIeT(flavorID, doubletID, energy, mediumID, 
+                        doCC, doNC, doMuBrems, doTauBrems, 
+                        doMuKnock, doTauKnock, doMu2e, doTau2e,
+                        doMu2mu, doTau2mu, doMu2tau, doTau2tau,
+                        doMuPN, doTauPN, doGR, doMuDecay,
+                        doTauDecay, posID, seed, random_state);
+
+    }
+
+
+    /** The same constructor, but without the glashow resoanance. 
+    This constructor exists to maintain the backward compatibility
+    */
+    public JulietEventGenerator4Gen2(int flavorID, int doubletID, double energy, int mediumID, 
+                                     int doCC, int doNC, int doMuBrems, int doTauBrems, 
+                                     int doMuKnock, int doTauKnock, int doMu2e, int doTau2e,
+                                     int doMu2mu, int doTau2mu, int doMu2tau, int doTau2tau,
+                                     int doMuPN, int doTauPN, int doMuDecay,
+                                     int doTauDecay, int posID, long seed) throws IOException{
+
+        int doGR = 0;
+        long[] random_state = null;
+
+        configureJULIeT(flavorID, doubletID, energy, mediumID, 
+                        doCC, doNC, doMuBrems, doTauBrems, 
+                        doMuKnock, doTauKnock, doMu2e, doTau2e,
+                        doMu2mu, doTau2mu, doMu2tau, doTau2tau,
+                        doMuPN, doTauPN, doGR, doMuDecay,
+                        doTauDecay, posID, seed, random_state);
+
+    }
+
+    /**
+      Constructor using the random_state for the generator.
+    */
+    public JulietEventGenerator4Gen2(int flavorID, int doubletID, double energy, int mediumID, 
+                                     int doCC, int doNC, int doMuBrems, int doTauBrems, 
+                                     int doMuKnock, int doTauKnock, int doMu2e, int doTau2e,
+                                     int doMu2mu, int doTau2mu, int doMu2tau, int doTau2tau,
+                                     int doMuPN, int doTauPN, int doGR, int doMuDecay,
+                                     int doTauDecay, int posID, long[] random_state) throws IOException{
+
+        long seed = -1;
+
+        configureJULIeT(flavorID, doubletID, energy, mediumID, 
+                        doCC, doNC, doMuBrems, doTauBrems, 
+                        doMuKnock, doTauKnock, doMu2e, doTau2e,
+                        doMu2mu, doTau2mu, doMu2tau, doTau2tau,
+                        doMuPN, doTauPN, doGR, doMuDecay,
+                        doTauDecay, posID, seed, random_state);
+
+    }
+
+
     public JulietEventGenerator4Gen2() throws IOException{
 
         int flavorID, doubletID, mediumID; 
@@ -223,9 +294,11 @@ public class JulietEventGenerator4Gen2 {
         int doMuKnock, doTauKnock, doMu2e, doTau2e;
         int doMu2mu, doTau2mu, doMu2tau, doTau2tau;
         int doMuPN, doTauPN, doMuDecay, doTauDecay, posID;
+        long seed;
+        long[] random_state = null;
 
-	/** For Glashow Resonance */
-	int doGR;
+	    /** For Glashow Resonance */
+	    int doGR;
 
         double energy;
 	
@@ -323,14 +396,17 @@ public class JulietEventGenerator4Gen2 {
 	buffer = d.readLine();
 	posID = Integer.valueOf(buffer).intValue();
 
+    System.out.print("Seed for the RandomGenerator");
+    buffer = d.readLine();
+    seed = Long.valueOf(buffer).longValue();
+
 	/** For Glashow Resonance */
-        configureJULIeT(flavorID, doubletID, energy, mediumID, 
-                        doCC, doNC, doMuBrems, doTauBrems, 
-                        doMuKnock, doTauKnock, doMu2e, doTau2e,
-                        doMu2mu, doTau2mu, doMu2tau, doTau2tau,
-                        doMuPN, doTauPN, 
-			doGR,
-			doMuDecay, doTauDecay, posID);
+    configureJULIeT(flavorID, doubletID, energy, mediumID, 
+                    doCC, doNC, doMuBrems, doTauBrems, 
+                    doMuKnock, doTauKnock, doMu2e, doTau2e,
+                    doMu2mu, doTau2mu, doMu2tau, doTau2tau,
+                    doMuPN, doTauPN, doGR, doMuDecay,
+                    doTauDecay, posID, seed, random_state);
     }
 
     /**
@@ -344,9 +420,9 @@ public class JulietEventGenerator4Gen2 {
                                  int doCC, int doNC, int doMuBrems, int doTauBrems, 
                                  int doMuKnock, int doTauKnock, int doMu2e, int doTau2e,
                                  int doMu2mu, int doTau2mu, int doMu2tau, int doTau2tau,
-                                 int doMuPN, int doTauPN, 
-				 int doGR,
-				 int doMuDecay, int doTauDecay, int posID) throws IOException{
+                                 int doMuPN, int doTauPN, int doGR, int doMuDecay,
+                                 int doTauDecay, int posID, long seed,
+                                 long[] random_state) throws IOException{
 
 
         primaryFlavor  = flavorID;
@@ -355,11 +431,21 @@ public class JulietEventGenerator4Gen2 {
         materialNumber = mediumID;
 
         // Generate Random Generator
-        rand = new RandomGenerator();
-        System.out.println("Random Generator has been generated");
+        if(random_state != null){
+            System.out.println("Using random_state to setup Random Generator");
+            rand = new RandomGenerator(random_state);
+        }
+        else if(seed != -1){
+            System.out.println("Using seed to setup Random Generator");
+            rand = new RandomGenerator(seed);
+        }
+        else{
+            System.out.println("Using system time to setup Random Generator");
+            rand = new RandomGenerator();
+        }
 
         // Register Interactions and read the InteractionMatrix objects
-	/** For Glashow Resonance 16->20*/
+	    /** For Glashow Resonance 16->20*/
         String[] fileName = new String[20];
         String matrixName = null;
         if(materialNumber==0)  interactionsMatrixDirectory = interactionsMatrixDirectoryInIce;
@@ -918,10 +1004,11 @@ public class JulietEventGenerator4Gen2 {
     public void runSingleEvent( ){
 
 	// generate the data list
-	particleList          = new LinkedList();
-	locationIce3List      = new LinkedList();
-	trackParticleList     = new LinkedList();
-	trackLocationIce3List = new LinkedList();
+	particleList          =    new LinkedList();
+    particleInteractionsList = new LinkedList();
+	locationIce3List      =    new LinkedList();
+	trackParticleList     =    new LinkedList();
+	trackLocationIce3List =    new LinkedList();
 
 	// generate a propagating particle
 	propParticle = new Particle(primaryFlavor,primaryDoublet,primaryEnergy);
@@ -935,10 +1022,10 @@ public class JulietEventGenerator4Gen2 {
 	particleAxis_J3Line_gen2.setAxisLength(startLocation);	// for IceCube-Gen2
 	particleAxis_J3Line_center.setAxisLength(startLocation);
 
-        // add propParticle to trackParticleList and trackLocationIce3List
-        // *** It's an initial primary track ***
-        trackParticleList.add(new Particle(primaryFlavor, primaryDoublet, primaryEnergy)); 
-        trackLocationIce3List.add(startLocation_J3Vector_ice3);
+    // add propParticle to trackParticleList and trackLocationIce3List
+    // *** It's an initial primary track ***
+    trackParticleList.add(new Particle(primaryFlavor, primaryDoublet, primaryEnergy)); 
+    trackLocationIce3List.add(startLocation_J3Vector_ice3);
 
 	// generate the particle point
 	point = new ParticlePoint(0.0, nadirAngleAtEntrance, materialNumber);
@@ -960,7 +1047,7 @@ public class JulietEventGenerator4Gen2 {
 
 	// flag to see if the collision is the week interaction/decay process.
 	boolean wasWeakInt = false;
-        boolean wasNC = false;
+    boolean wasNC = false;
 	boolean wasDecay = false;
 	/** For Glashow Resonance */
 	boolean wasGR = false;
@@ -1024,16 +1111,16 @@ public class JulietEventGenerator4Gen2 {
 
 		double transferedEnergy  = event.collideNow(rand);
 
-                // get current interaction's name
-                String   curInteractionsName  = event.interactionsNameInPlay();
+        // get current interaction's name
+        String   curInteractionsName  = event.interactionsNameInPlay();
 
-                // Collision occured by NC, WeakInteraction(CC, NC), Decay or Glashow Resonance?
-                wasWeakInt = curInteractionsName.startsWith("Neutrino-Nuclen ");
-                wasNC      = curInteractionsName.startsWith("Neutrino-Nuclen N");
-		wasDecay   = (event.mcBaseInPlay.getTypeOfInteraction() == 1);
+        // Collision occured by NC, WeakInteraction(CC, NC), Decay or Glashow Resonance?
+        wasWeakInt = curInteractionsName.startsWith("Neutrino-Nuclen ");
+        wasNC      = curInteractionsName.startsWith("Neutrino-Nuclen N");
+        wasDecay   = (event.mcBaseInPlay.getTypeOfInteraction() == 1);
 		/** For Glashow Resonance */
-                wasGR = curInteractionsName.startsWith("Glashow ");
-                wasGRLepton = curInteractionsName.startsWith("Glashow Resonance Leptonic ");
+        wasGR = curInteractionsName.startsWith("Glashow ");
+        wasGRLepton = curInteractionsName.startsWith("Glashow Resonance Leptonic ");
 
 		// get produced particle's name
 		//String   producedParticleName = Particle.particleName(
@@ -1043,21 +1130,21 @@ public class JulietEventGenerator4Gen2 {
 		//		           event.getFlavorByInteractionsInPlay(),0);
 		//}
 
-                // get current propagation particle
-                Particle curPropParticle        = event.propParticle;
-                int      curPropParticleFlavor  = curPropParticle.getFlavor();
-                int      curPropParticleDoublet = curPropParticle.getDoublet();
-                String   curPropParticleName    = Particle.particleName(curPropParticleFlavor,
-                                                                        curPropParticleDoublet);
+        // get current propagation particle
+        Particle curPropParticle        = event.propParticle;
+        int      curPropParticleFlavor  = curPropParticle.getFlavor();
+        int      curPropParticleDoublet = curPropParticle.getDoublet();
+        String   curPropParticleName    = Particle.particleName(curPropParticleFlavor,
+                                                                curPropParticleDoublet);
 
                 
 		//System.out.println("Colliding via " + curInteractionsName +
 		//            " and producing " + producedParticleName);
 		//System.out.println("  -Current propagation particle : " + curPropParticleName);
 
-                // add prpagation track to the lists
-                boolean addTrack = false;
-                if (curPropParticleFlavor == 1) { // muon flavor
+        // add prpagation track to the lists
+        boolean addTrack = false;
+        if (curPropParticleFlavor == 1) { // muon flavor
 
 		    if (wasWeakInt || wasDecay || wasGR) addTrack = true;
 
@@ -1071,12 +1158,12 @@ public class JulietEventGenerator4Gen2 {
 		    }
 		}
 
-                if (addTrack) {
-                   trackParticleList.add(new Particle(curPropParticle.getFlavor(), 
-                                                      curPropParticle.getDoublet(),
-                                                      curPropParticle.getEnergy())); 
-                   trackLocationIce3List.add(particleLocation_J3Vector_ice3);
-                }
+        if (addTrack) {
+           trackParticleList.add(new Particle(curPropParticle.getFlavor(), 
+                                              curPropParticle.getDoublet(),
+                                              curPropParticle.getEnergy())); 
+           trackLocationIce3List.add(particleLocation_J3Vector_ice3);
+        }
 
                 // add secondary cascade to the lists
 		if ((event.getFlavorByInteractionsInPlay()==0 && !wasGR) || 
@@ -1086,11 +1173,12 @@ public class JulietEventGenerator4Gen2 {
 		    particleList.add(new Particle(event.getFlavorByInteractionsInPlay(),
 						  1,transferedEnergy));
 		    locationIce3List.add(particleLocation_J3Vector_ice3);
+            particleInteractionsList.add(curInteractionsName);
 		}else if(wasGRLepton){ // The GR produced neurtino as a propagating particle
 		    particleList.add(new Particle(event.getFlavorByInteractionsInPlay(),
 						  0,transferedEnergy)); // neutrino
 		    locationIce3List.add(particleLocation_J3Vector_ice3);
-
+            particleInteractionsList.add(curInteractionsName);
 		}else{  // producing secondary track. current version of JULIeT
                         // ignore secondary tracks.
 
@@ -1101,7 +1189,7 @@ public class JulietEventGenerator4Gen2 {
 
 	    double afterInteractionLogEnergy = event.propParticle.getLogEnergy(); 
                                            // logEnergy after interaction
-            double afterInteractionEnergy = event.propParticle.getEnergy();
+        double afterInteractionEnergy = event.propParticle.getEnergy();
                                            // Energy after interaction
         
             //System.out.println("logEnergy after interaction is  "+ afterInteractionLogEnergy);
@@ -1188,7 +1276,9 @@ public class JulietEventGenerator4Gen2 {
     public ListIterator getTrackParticleIterator(){
 	return trackParticleList.listIterator();
     }
-
+    public ListIterator getParticleInteractionsIterator(){
+    return particleInteractionsList.listIterator();
+    }
 
     /** Return location hit iterator which allows
 	an external object to access each location
@@ -1200,7 +1290,14 @@ public class JulietEventGenerator4Gen2 {
 	return trackLocationIce3List.listIterator();
     }
 
+    public long[] getRandomState(){
+        long[] state = rand.GetState();
+        return state;
+    }
 
+    public void setRandomState(long[] state){
+        rand = new RandomGenerator(state);
+    }
 
     /** Method to run multiple events (numberOfEvent) 
         with various primary energies from

--- a/sources/iceCube/uhe/event/JulietTask.java
+++ b/sources/iceCube/uhe/event/JulietTask.java
@@ -228,7 +228,8 @@ public class JulietTask {
                                 doCC, doNC, doMuBrems, doTauBrems, 
                                 doMuKnock, doTauKnock, doMu2e, doTau2e,
                                 doMu2mu, doTau2mu, doMu2tau, doTau2tau,
-                                doMuPN, doTauPN, doMuDecay, doTauDecay, 0);
+                                doMuPN, doTauPN, doMuDecay, doTauDecay, 0,
+                                System.currentTimeMillis());
 	swingRun.messageField.setText("done!");
 	}catch(IOException e) {
             swingRun.messageField.setText("IOException: " + e.getMessage());

--- a/sources/iceCube/uhe/event/MakeJuliet4Gen2JaidaTree.java
+++ b/sources/iceCube/uhe/event/MakeJuliet4Gen2JaidaTree.java
@@ -74,7 +74,7 @@ public class MakeJuliet4Gen2JaidaTree {
 					   doCC, doNC, doMuBrems, doTauBrems,
 					   doMuKnock, doTauKnock, doMu2e, doTau2e,
 					   doMu2mu, doTau2mu, doMu2tau, doTau2tau,
-					   doMuPN, doTauPN, doGR, doMuDecay, doTauDecay,posID);
+					   doMuPN, doTauPN, doGR, doMuDecay, doTauDecay, posID);
 
 	// Jaida FreeHep objects
         IAnalysisFactory jaidaFactory = IAnalysisFactory.create();

--- a/sources/iceCube/uhe/interactions/RunJulietAndCalcLikelihood.java
+++ b/sources/iceCube/uhe/interactions/RunJulietAndCalcLikelihood.java
@@ -74,7 +74,8 @@ public class RunJulietAndCalcLikelihood {
 	    				   doCC, doNC, doMuBrems, doTauBrems,
 	    				   doMuKnock, doTauKnock, doMu2e, doTau2e,
 	    				   doMu2mu, doTau2mu, doMu2tau, doTau2tau,
-	    				   doMuPN, doTauPN, doGR, doMuDecay, doTauDecay,posID);
+	    				   doMuPN, doTauPN, doGR, doMuDecay, doTauDecay,posID,
+	    				   System.currentTimeMillis());
 	//new  JulietEventGenerator(flavorID, doubletID, inice_initial_energy, mediumID,
 	//				   0, 0, 0, 0,
 	//				   0, 0, 0, 0,

--- a/sources/numRecipes/RandomDouble.java
+++ b/sources/numRecipes/RandomDouble.java
@@ -66,27 +66,41 @@ public class RandomDouble implements Serializable{
     private static final long LMASK = 0x7fffffffL; 
     // least significant r bits 
     private long[] state; // the array for the state vector
+    private long[] random_state; // the array for the state vector including the current index
     private int left = 1;
     private int initf = 0;
     private int selectedIndex;
 
-
-
     /** Constructor to initialize state[N] with a seed */
     public RandomDouble(long s) {
-	int j;
-	state =  new long[N];
-	state[0]= s & 0xffffffffL;
+	    int j;
+	    state =  new long[N];
+	    state[0]= s & 0xffffffffL;
 
-	for (j=1; j<N; j++) {
-	    state[j] = (1812433253L * (state[j-1] ^ (state[j-1] >> 30)) + (long )j); 
-	    // See Knuth TAOCP Vol2. 3rd Ed. P.106 for multiplier.
-	    // In the previous versions, MSBs of the seed affect   
-	    // only MSBs of the array state[].                     
-	    // 2002/01/09 modified by Makoto Matsumoto             
-	    state[j] &= 0xffffffffL;  // for >32 bit machines 
-	}
-	left = 1; initf = 1;
+	    for (j=1; j<N; j++) {
+  	    state[j] = (1812433253L * (state[j-1] ^ (state[j-1] >> 30)) + (long )j); 
+  	    // See Knuth TAOCP Vol2. 3rd Ed. P.106 for multiplier.
+  	    // In the previous versions, MSBs of the seed affect   
+  	    // only MSBs of the array state[].                     
+  	    // 2002/01/09 modified by Makoto Matsumoto             
+  	    state[j] &= 0xffffffffL;  // for >32 bit machines 
+ 	    }
+	    left = 1; initf = 1;
+    }
+
+    public RandomDouble(long[] init_state){
+      state = new long[N];
+      System.arraycopy(init_state, 0, state, 0, N);
+      selectedIndex = (int) init_state[N];
+      left = (int) init_state[N+1];
+    }
+
+    public long[] GetState(){
+      random_state = new long[N+2];
+      System.arraycopy(state, 0, random_state, 0, N);
+      random_state[N] = selectedIndex;
+      random_state[N+1] = left;
+      return random_state;
     }
 
     public long MixBits(long u, long v){

--- a/sources/numRecipes/RandomGenerator.java
+++ b/sources/numRecipes/RandomGenerator.java
@@ -35,6 +35,17 @@ public class RandomGenerator implements Serializable{
 
     }
 
+	/** constructor with a given random state. */
+    public RandomGenerator(long[] random_state) {
+	    if(generator == null){ // Initialization
+	        generator = new RandomDouble(random_state);
+	    }
+    }
+
+    public long[] GetState(){
+      long[] state = generator.GetState();
+      return state;
+    }
 
     public double GetRandomDouble( ) { // Get the preudorandom distributed 
 	                               // uniformly.

--- a/sources/numRecipes/RandomGeneratorState.java
+++ b/sources/numRecipes/RandomGeneratorState.java
@@ -1,0 +1,49 @@
+package numRecipes;
+
+import numRecipes.*;
+
+
+/** Display the pseudorandom numbers */
+public class RandomGeneratorState{
+
+    public static void main(String[] args){
+
+		RandomGenerator random1 = new RandomGenerator(123);
+        double r;
+        int times = 0;
+
+		if(args.length!=1){
+		    System.out.println("Usage: RandomDoubleDemo repeat-times");
+		}
+		else{
+		    times = Integer.valueOf(args[0]).intValue();
+		}
+
+		for(int i=0;i<times;i++){
+		    r = random1.GetRandomDouble();
+		    System.out.println("Pseudorandom (" + i + "):" + r);
+		}
+
+		long[] state = random1.GetState();
+
+		for(int i=0;i<5;i++){
+		    r = random1.GetRandomDouble();
+		    System.out.println("Pseudorandom1 (" + i + "):" + r);
+		}
+
+		// for(int i=0; i<state.length; i++){
+		//	System.out.println(state[i]);
+		//}
+
+		System.out.println("Before init");
+		RandomGenerator random2 = new RandomGenerator(state);
+		System.out.println("After init");
+
+		for(int i=0;i<5;i++){
+	        r = random2.GetRandomDouble();
+	        System.out.println("Pseudorandom2 (" + i + "):" + r);
+		}
+    }
+
+}
+


### PR DESCRIPTION
I've added the possibility to either use a random seed when construction the JulietEventGenerator, or to supply a complete random state to the RandomGenerator class. This allows to even reproduce the propagation result for only one specific when the random state is saved in the Frame when Juliet is used in the icetray context.

Added a getter for the particle interaction, to be able to identify the interactions that happened retroactively after propagating an event. 